### PR TITLE
Index Hit IP and session

### DIFF
--- a/hitcount/migrations/0002_index_ip_and_session.py
+++ b/hitcount/migrations/0002_index_ip_and_session.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('hitcount', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='hit',
+            name='ip',
+            field=models.CharField(max_length=40, db_index=True, editable=False),
+        ),
+        migrations.AlterField(
+            model_name='hit',
+            name='session',
+            field=models.CharField(max_length=40, db_index=True, editable=False),
+        ),
+        migrations.AlterField(
+            model_name='hitcount',
+            name='object_pk',
+            field=models.PositiveIntegerField(verbose_name='object ID'),
+        ),
+    ]

--- a/hitcount/models.py
+++ b/hitcount/models.py
@@ -112,8 +112,8 @@ class Hit(models.Model):
 
     """
     created = models.DateTimeField(editable=False, auto_now_add=True, db_index=True)
-    ip = models.CharField(max_length=40, editable=False)
-    session = models.CharField(max_length=40, editable=False)
+    ip = models.CharField(max_length=40, editable=False, db_index=True)
+    session = models.CharField(max_length=40, editable=False, db_index=True)
     user_agent = models.CharField(max_length=255, editable=False)
     user = models.ForeignKey(AUTH_USER_MODEL, null=True, editable=False)
     hitcount = models.ForeignKey(HitCount, editable=False)


### PR DESCRIPTION
Not indexing IP and session was causing some lag in a database with
more than a million hits. After indexing, performance was greatly
improved.